### PR TITLE
GHCJS.VDOM.Unsafe: exporting js_vnode and internal javascript references...

### DIFF
--- a/ghcjs-vdom.cabal
+++ b/ghcjs-vdom.cabal
@@ -44,8 +44,9 @@ library
   ghcjs-options: -O2 -Wall
   exposed-modules:     GHCJS.VDOM
                        GHCJS.VDOM.QQ
+                       GHCJS.VDOM.Unsafe
   other-modules:       GHCJS.VDOM.Internal
-  build-depends:       base >=4.7 && <4.8,
+  build-depends:       base >=4.7 && <4.9,
                        ghcjs-ffiqq,
                        ghcjs-base,
                        ghcjs-prim,

--- a/src/GHCJS/VDOM.hs
+++ b/src/GHCJS/VDOM.hs
@@ -183,9 +183,6 @@ a :: Properties -> Children -> VNode
 a = js_vnode "a"
 {-# INLINE a #-}
 
-js_vnode :: JSString -> Properties -> Children -> VNode
-js_vnode tag (Properties props) (Children children) =
-  VNode [jsu'| new h$vdom.VNode(`tag, `props, `children) |]
 
 ---- these things should be in ghcjs-prim
 

--- a/src/GHCJS/VDOM/Internal.hs
+++ b/src/GHCJS/VDOM/Internal.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE JavaScriptFFI #-}
+{-# LANGUAGE QuasiQuotes #-}
+
 module GHCJS.VDOM.Internal where
 
 import Language.Haskell.TH.Quote
@@ -22,4 +26,7 @@ type J = JSRef ()
 j :: QuasiQuoter
 j = jsu'
 
+js_vnode :: JSString -> Properties -> Children -> VNode
+js_vnode tag (Properties props) (Children children) =
+  VNode [jsu'| new h$vdom.VNode(`tag, `props, `children) |]
 

--- a/src/GHCJS/VDOM/Unsafe.hs
+++ b/src/GHCJS/VDOM/Unsafe.hs
@@ -1,0 +1,9 @@
+module GHCJS.VDOM.Unsafe ( Properties(..)
+                         , Children(..)
+                         , VNode(..)
+                         , Patch(..)
+                         , js_vnode ) where
+
+import GHCJS.VDOM
+import GHCJS.VDOM.Internal
+


### PR DESCRIPTION
... for Properties, Children, Patch and VNode

I exported those to make use of ghcjs-vdom for webcomponent custom element (such as Polymer elements). This issue was discussed in #6 
