### PR TITLE
Expose event target

### DIFF
--- a/src/GHCJS/VDOM/Event.hs
+++ b/src/GHCJS/VDOM/Event.hs
@@ -7,7 +7,7 @@
 
 module GHCJS.VDOM.Event ( initEventDelegation
                         , defaultEvents
---                        , target
+                        , target
                         , stopPropagation
                         , stopImmediatePropagation
                         , preventDefault
@@ -136,6 +136,10 @@ defaultEvents = $(mkDefaultEvents)
 
 -- target :: Event_ a => a -> VNode
 -- target e = undefined
+
+target :: Event_ a => a -> JSVal
+target = er $ \e -> [jsu'| `e.target |]
+{-# INLINE target #-}
 
 stopPropagation :: Event_ a => a -> IO ()
 stopPropagation = er $ \e -> [jsu_| `e.stopPropagation(); |]

--- a/src/GHCJS/VDOM/Event.hs
+++ b/src/GHCJS/VDOM/Event.hs
@@ -69,6 +69,12 @@ module GHCJS.VDOM.Event ( initEventDelegation
                         , deltaY
                         , deltaZ
                         , deltaMode
+
+                          -- * input
+                        , InputEvent
+                        , input
+                          --
+                        , inputValue
                           
                           -- * generic
                         , Event
@@ -96,10 +102,12 @@ class Coercible a JSVal => Event_ a
 class Event_ a          => KeyModEvent_ a
 class Event_ a          => MouseEvent_ a
 class Event_ a          => FocusEvent_ a
+class Event_ a          => InputEvent_ a
 
 mkEventTypes ''Event_ [ ("MouseEvent",    [''MouseEvent_])
                       , ("KeyboardEvent", [''KeyModEvent_])
                       , ("FocusEvent",    [''FocusEvent_])
+                      , ("InputEvent",    [''InputEvent_])
                       , ("DragEvent",     [])
                       , ("WheelEvent",    [])
                       , ("UIEvent",       [])
@@ -112,6 +120,8 @@ mkEvents 'MouseEvent [ "click", "dblclick", "mousedown", "mouseenter"
                      ]
 
 mkEvents 'KeyboardEvent [ "keydown", "keypress", "keyup" ]
+
+mkEvents 'InputEvent [ "input" ]
 
 mkEvents 'DragEvent [ "drag", "dragend", "dragenter", "dragleave"
                     , "dragover", "dragstart" ]
@@ -200,3 +210,7 @@ clientX = er $ \e -> [jsu'| `e.clientX|0 |]
 clientY :: MouseEvent -> Int
 clientY = er $ \e -> [jsu'| `e.clientY|0 |]
 {-# INLINE clientY #-}
+
+inputValue :: InputEvent -> JSString
+inputValue = er $ \e -> [jsu'| String(`e.target.value||'') |]
+{-# INLINE inputValue #-}


### PR DESCRIPTION
There was already some commented-out code in place to expose the `target` of an event; I assume it was commented out because the type signature wants `target` to return a `VNode`, but it is unclear how to marshal the value back to a `VNode`. Personally, I believe that return value is wrong, because `VNode` is a _virtual_ DOM node, but what we get from `event.target` is an _actual_ DOM node, and the virtual-dom works, virtual → actual is one-way (or that's what I gathered).

Anyway, since marshalling from JS DOM nodes to `VNode` isn't very useful anyway IMO, I changed things such that the DOM node is just returned as-is, as a `JSVal`. This is obviously not typesafe, but other than that, it works, and allows me to pull properties out of the event target (in my particular use case, the `value`, which gets fed back into the reactive event loop on the Haskell side of things).

A proper solution would instead marshal to a properly typed something, but I figured that'd be a future improvement.
